### PR TITLE
Allow branch name to be passed as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Navigate to the folder with the `package.json`, and run `gup`.
 |-------------|-------|---------|---------------------------------------------------------------------------------------------------|
 | --help      |       | boolean | Show help                                                                                         |
 | --version   |       | boolean | Show version number                                                                               |
+| --branch    | -b    | string | Name of the branch to publish the UPM package to. Defaults to "upm".                               |
 | --force     | -f    | boolean | Disable checks and execute snapshot with force flag.                                              |
 | --noPush    | -n    | boolean | Disable auto-pushing of the upm branch to the origin.                                             |
 | --noCommit  | -c    | boolean | Disable the auto-commit before publishing that includes the version change in the 'package.json'. |

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,6 +1,12 @@
 import yargs from "yargs";
 
 export const args = yargs
+  .option("branch", {
+    alias: "b",
+    type: "string",
+    default: "upm",
+    description: "Name of the branch to publish the UPM package to."
+  })
   .option("force", {
     alias: "f",
     type: "boolean",
@@ -9,7 +15,7 @@ export const args = yargs
   .option("noPush", {
     alias: "n",
     type: "boolean",
-    description: "Disable auto-pushing of the upm branch to the origin."
+    description: "Disable auto-pushing of the UPM package branch to the origin."
   })
   .option("noCommit", {
     alias: "c",

--- a/src/execute-snapshot.ts
+++ b/src/execute-snapshot.ts
@@ -5,6 +5,7 @@ import { findRepoRoot } from "./utils/find-repo-root";
 export async function executeSnapshot(
   packagePath: path.ParsedPath,
   version: string,
+  branch: string,
   noPush: boolean,
   force: boolean,
   tagPrefix: string
@@ -15,11 +16,11 @@ export async function executeSnapshot(
 
   const opts: any = {
     prefix: packagePathStr,
-    branch: "upm",
+    branch,
     message: `upm release ${version}`,
     author:
       "git-upm-publisher <https://github.com/starikcetin/git-upm-publisher-2/>",
-    force: force,
+    force,
     tag: tagPrefix + version,
     dryRun: false,
     cwd: gitRepoPathStr

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,14 @@
 import path from "path";
 import { args } from "./args";
 import { executeSnapshot } from "./execute-snapshot";
+import { makeVersionCommit } from "./make-version-commit";
 import { updateVersion } from "./update-version";
 import { checkFileReadWrite } from "./utils/check-file-read-write";
 import { checkRepoStatus } from "./utils/check-repo-status";
 import { getPackageJsonPath } from "./utils/get-package-json-path";
-import { makeVersionCommit } from "./make-version-commit";
 import { makePathAbsolute } from "./utils/make-path-absolute";
 
+const branch = args.branch;
 const force = !!args.force;
 const noPush = !!args.noPush;
 const noCommit = !!args.noCommit;
@@ -35,7 +36,7 @@ export async function main() {
     await makeVersionCommit(packageJsonPath, newVersion);
   }
 
-  await executeSnapshot(packageJsonPath, newVersion, noPush, force, tagPrefix);
+  await executeSnapshot(packageJsonPath, newVersion, branch, noPush, force, tagPrefix);
 }
 
 async function handleArgs() {


### PR DESCRIPTION
I've added a new `--branch` argument that defaults to `"upm"` to enable specifying the name of the branch that the UPM package is published to. 

This, in conjunction with the existing `--tagPrefix` argument will allow the tool to be used with monorepos containing several UPM packages, as each will need to be published to a separate branch.