### PR TITLE
Allow overriding the commit author to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Navigate to the folder with the `package.json`, and run `gup`.
 | --version   |       | boolean | Show version number                                                                               |
 | --branch    | -b    | string | Name of the branch to publish the UPM package to. Defaults to "upm".                               |
 | --force     | -f    | boolean | Disable checks and execute snapshot with force flag.                                              |
+| --noAuthor  | -a    | boolean | Disable overriding the commit author for auto-commits made by this tool.                          |
 | --noPush    | -n    | boolean | Disable auto-pushing of the upm branch to the origin.                                             |
 | --noCommit  | -c    | boolean | Disable the auto-commit before publishing that includes the version change in the 'package.json'. |
 | --package   | -p    | string  | Skip searching and use this package.json path (must include 'package.json').                      |

--- a/src/args.ts
+++ b/src/args.ts
@@ -12,6 +12,11 @@ export const args = yargs
     type: "boolean",
     description: "Disable checks and execute snapshot with force flag."
   })
+  .option("noAuthor", {
+    alias: "a",
+    type: "boolean",
+    description: "Disable overriding the commit author for auto-commits made by this tool."
+  })
   .option("noPush", {
     alias: "n",
     type: "boolean",

--- a/src/execute-snapshot.ts
+++ b/src/execute-snapshot.ts
@@ -1,12 +1,14 @@
 import gitSnapshot from "git-snapshot";
 import path from "path";
 import { findRepoRoot } from "./utils/find-repo-root";
+import { getAuthor } from "./utils/get-author";
 
 export async function executeSnapshot(
   packagePath: path.ParsedPath,
   version: string,
   branch: string,
   noPush: boolean,
+  noAuthor: boolean,
   force: boolean,
   tagPrefix: string
 ) {
@@ -18,8 +20,6 @@ export async function executeSnapshot(
     prefix: packagePathStr,
     branch,
     message: `upm release ${version}`,
-    author:
-      "git-upm-publisher <https://github.com/starikcetin/git-upm-publisher-2/>",
     force,
     tag: tagPrefix + version,
     dryRun: false,
@@ -28,6 +28,10 @@ export async function executeSnapshot(
 
   if (!noPush) {
     opts.remote = "origin";
+  }
+
+  if (!noAuthor) {
+    opts.author = await getAuthor();
   }
 
   return gitSnapshot(opts);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { makePathAbsolute } from "./utils/make-path-absolute";
 
 const branch = args.branch;
 const force = !!args.force;
+const noAuthor = !!args.noAuthor;
 const noPush = !!args.noPush;
 const noCommit = !!args.noCommit;
 let packageJsonPath: path.ParsedPath;
@@ -33,10 +34,10 @@ export async function main() {
   console.log("<main> New version:", newVersion);
 
   if (!noCommit) {
-    await makeVersionCommit(packageJsonPath, newVersion);
+    await makeVersionCommit(packageJsonPath, newVersion, noAuthor);
   }
 
-  await executeSnapshot(packageJsonPath, newVersion, branch, noPush, force, tagPrefix);
+  await executeSnapshot(packageJsonPath, newVersion, branch, noPush, noAuthor, force, tagPrefix);
 }
 
 async function handleArgs() {

--- a/src/make-version-commit.ts
+++ b/src/make-version-commit.ts
@@ -1,10 +1,12 @@
 import path from "path";
-import { findRepoRoot } from "./utils/find-repo-root";
 import simpleGit from "simple-git/promise";
+import { findRepoRoot } from "./utils/find-repo-root";
+import { getAuthor } from "./utils/get-author";
 
 export async function makeVersionCommit(
   packageJsonPath: path.ParsedPath,
-  version: string
+  version: string,
+  noAuthor: boolean
 ) {
   const packageJsonPathStr = path.format(packageJsonPath);
   const gitRepoPath = await findRepoRoot(packageJsonPath);
@@ -12,13 +14,16 @@ export async function makeVersionCommit(
 
   const git = simpleGit(gitRepoPathStr);
 
+  const opts : simpleGit.Options = {};
+
+  if (!noAuthor) {
+    opts["--author"] = await getAuthor();
+  }
+
   await git.add(packageJsonPathStr);
   await git.commit(
     `version change for upm release (${version})`,
     packageJsonPathStr,
-    {
-      "--author":
-        "git-upm-publisher <https://github.com/starikcetin/git-upm-publisher-2/>"
-    }
+    opts
   );
 }

--- a/src/utils/get-author.ts
+++ b/src/utils/get-author.ts
@@ -1,0 +1,5 @@
+const pjson = require('../../package.json')
+
+export async function getAuthor() {
+    return `${pjson.name} <${pjson.homepage}>`;
+}


### PR DESCRIPTION
This PR adds a `--noAuthor` argument to allow the default behaviour of overriding the commit author to be disabled. It also adds a function to generate an author string from the module's `package.json`, rather than relying on hard-coded values.