### PR TITLE
Include tag prefix in commit message

### DIFF
--- a/src/execute-snapshot.ts
+++ b/src/execute-snapshot.ts
@@ -19,7 +19,7 @@ export async function executeSnapshot(
   const opts: any = {
     prefix: packagePathStr,
     branch,
-    message: `upm release ${version}`,
+    message: `UPM release ${tagPrefix}${version}`,
     force,
     tag: tagPrefix + version,
     dryRun: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,9 @@ const force = !!args.force;
 const noAuthor = !!args.noAuthor;
 const noPush = !!args.noPush;
 const noCommit = !!args.noCommit;
+const tagPrefix = args.tagPrefix;
+
 let packageJsonPath: path.ParsedPath;
-let tagPrefix = args.tagPrefix;
 
 export async function main() {
   await handleArgs();
@@ -31,10 +32,10 @@ export async function main() {
   }
 
   const newVersion = await updateVersion(packageJsonPath);
-  console.log("<main> New version:", newVersion);
+  console.log(`<main> New version: ${tagPrefix}${newVersion}`);
 
   if (!noCommit) {
-    await makeVersionCommit(packageJsonPath, newVersion, noAuthor);
+    await makeVersionCommit(packageJsonPath, newVersion, noAuthor, tagPrefix);
   }
 
   await executeSnapshot(packageJsonPath, newVersion, branch, noPush, noAuthor, force, tagPrefix);

--- a/src/make-version-commit.ts
+++ b/src/make-version-commit.ts
@@ -6,7 +6,8 @@ import { getAuthor } from "./utils/get-author";
 export async function makeVersionCommit(
   packageJsonPath: path.ParsedPath,
   version: string,
-  noAuthor: boolean
+  noAuthor: boolean,
+  tagPrefix: string
 ) {
   const packageJsonPathStr = path.format(packageJsonPath);
   const gitRepoPath = await findRepoRoot(packageJsonPath);
@@ -22,7 +23,7 @@ export async function makeVersionCommit(
 
   await git.add(packageJsonPathStr);
   await git.commit(
-    `version change for upm release (${version})`,
+    `Version change for UPM release (${tagPrefix}${version})`,
     packageJsonPathStr,
     opts
   );


### PR DESCRIPTION
Another PR that will help make this tool more useful when managing a packages monorepo. Including the `--tagPrefix` (if any) in the commit message will allow version bumps of different packages to be differentiated between if using a tag prefix scheme like `packagename/v`

Example output:

`Version change for UPM release (packagename/v1.0.0)`

and

`UPM release (packagename/v1.0.0)`