### PR TITLE
Remote and local branch checks & pulling the upm branch before and after publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Navigate to the folder with the `package.json`, and run `gup`.
 |-------------|-------|---------|---------------------------------------------------------------------------------------------------|
 | --help      |       | boolean | Show help                                                                                         |
 | --version   |       | boolean | Show version number                                                                               |
-| --branch    | -b    | string | Name of the branch to publish the UPM package to. Defaults to "upm".                               |
+| --remote    | -r    | string  | Name of the remote where UPM package branch resides or will reside. Defaults to "origin".         |
+| --branch    | -b    | string  | Name of the branch to publish the UPM package to. Defaults to "upm".                              |
 | --force     | -f    | boolean | Disable checks and execute snapshot with force flag.                                              |
 | --noAuthor  | -a    | boolean | Disable overriding the commit author for auto-commits made by this tool.                          |
 | --noPush    | -n    | boolean | Disable auto-pushing of the upm branch to the origin.                                             |
+| --noPull    | -l    | boolean | Disable pulling of the UPM package branch before and after the publishing process.                |
 | --noCommit  | -c    | boolean | Disable the auto-commit before publishing that includes the version change in the 'package.json'. |
 | --package   | -p    | string  | Skip searching and use this package.json path (must include 'package.json').                      |
 | --tagPrefix | -t    | string  | A prefix for the git tag.                                                                         |

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,7 +6,7 @@ export const args = yargs
     alias: "r",
     type: "string",
     default: "origin",
-    description: "Name of the remote to publish the UPM package to."
+    description: "Name of the remote where UPM package branch resides or will reside."
   })
   .option("branch", {
     alias: "b",
@@ -32,7 +32,7 @@ export const args = yargs
   .option("noPull", {
     alias: "l",
     type: "boolean",
-    description: "Disable pulling of the UPM package branch before starting the pulishing process."
+    description: "Disable pulling of the UPM package branch before and after the publishing process."
   })
   .option("noCommit", {
     alias: "c",

--- a/src/args.ts
+++ b/src/args.ts
@@ -2,6 +2,12 @@ import yargs from "yargs";
 
 export const args = yargs
   .strict()
+  .option("remote", {
+    alias: "r",
+    type: "string",
+    default: "origin",
+    description: "Name of the remote to publish the UPM package to."
+  })
   .option("branch", {
     alias: "b",
     type: "string",
@@ -22,6 +28,11 @@ export const args = yargs
     alias: "n",
     type: "boolean",
     description: "Disable auto-pushing of the UPM package branch to the origin."
+  })
+  .option("noPull", {
+    alias: "l",
+    type: "boolean",
+    description: "Disable pulling of the UPM package branch before starting the pulishing process."
   })
   .option("noCommit", {
     alias: "c",

--- a/src/execute-snapshot.ts
+++ b/src/execute-snapshot.ts
@@ -10,7 +10,8 @@ export async function executeSnapshot(
   noPush: boolean,
   noAuthor: boolean,
   force: boolean,
-  tagPrefix: string
+  tagPrefix: string,
+  remote: string
 ) {
   const packagePathStr = packagePath.dir;
   const gitRepoPath = await findRepoRoot(packagePath);
@@ -27,7 +28,7 @@ export async function executeSnapshot(
   };
 
   if (!noPush) {
-    opts.remote = "origin";
+    opts.remote = remote;
   }
 
   if (!noAuthor) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ export async function main() {
   const isFirstTime = !(remoteBranchExists || localBranchExists);
 
   if(localBranchExists && !remoteBranchExists) {
-    console.warn(`<main> A branch named ${branch} exists locally, but not on the remote. Pulling will be skipped.`);
+    console.warn(`<main> A branch named ${branch} exists locally, but not on the remote ${remote}. Pulling will be skipped.`);
   }
 
   if(isFirstTime) {
@@ -67,7 +67,9 @@ export async function main() {
 
   await executeSnapshot(packageJsonPath, newVersion, branch, noPush, noAuthor, force, tagPrefix, remote);
 
-  await pullUpmBranch(packageJsonPath, branch, remote);
+  if(!noPull) {
+    await pullUpmBranch(packageJsonPath, branch, remote);
+  }
 }
 
 async function handleArgs() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,13 +7,20 @@ import { checkFileReadWrite } from "./utils/check-file-read-write";
 import { checkRepoStatus } from "./utils/check-repo-status";
 import { getPackageJsonPath } from "./utils/get-package-json-path";
 import { makePathAbsolute } from "./utils/make-path-absolute";
+import { pullUpmBranch } from "./pull-upm-branch";
+import { hasRemote } from "./utils/has-remote";
+import { hasRemoteBranch } from "./utils/has-remote-branch";
+import { hasLocalBranch } from "./utils/has-local-branch";
+import { learnVersion } from "./utils/learn-version";
 
 const branch = args.branch;
 const force = !!args.force;
 const noAuthor = !!args.noAuthor;
 const noPush = !!args.noPush;
+const noPull = !!args.noPull;
 const noCommit = !!args.noCommit;
 const tagPrefix = args.tagPrefix;
+const remote = args.remote;
 
 let packageJsonPath: path.ParsedPath;
 
@@ -31,14 +38,36 @@ export async function main() {
     await checkRepoStatus(packageJsonPath);
   }
 
-  const newVersion = await updateVersion(packageJsonPath);
-  console.log(`<main> New version: ${tagPrefix}${newVersion}`);
+  const remoteExists = await hasRemote(packageJsonPath, remote);
+  const remoteBranchExists = remoteExists && await hasRemoteBranch(packageJsonPath, remote, branch);
+  const localBranchExists = await hasLocalBranch(packageJsonPath, branch);
 
-  if (!noCommit) {
+  const isFirstTime = !(remoteBranchExists || localBranchExists);
+
+  if(localBranchExists && !remoteBranchExists) {
+    console.warn(`<main> A branch named ${branch} exists locally, but not on the remote. Pulling will be skipped.`);
+  }
+
+  if(isFirstTime) {
+    console.log("<main> First time publishing. Version prompt will be skipped.");
+  }
+
+  if(!noPull && remoteBranchExists) {
+    await pullUpmBranch(packageJsonPath, branch, remote);
+  }
+
+  const currentVersion = await learnVersion(packageJsonPath);
+  const newVersion = isFirstTime ? currentVersion : await updateVersion(packageJsonPath, currentVersion);
+
+  console.log(`<main> Version to publish: ${tagPrefix}${newVersion}`);
+
+  if(!noCommit && !isFirstTime) {
     await makeVersionCommit(packageJsonPath, newVersion, noAuthor, tagPrefix);
   }
 
-  await executeSnapshot(packageJsonPath, newVersion, branch, noPush, noAuthor, force, tagPrefix);
+  await executeSnapshot(packageJsonPath, newVersion, branch, noPush, noAuthor, force, tagPrefix, remote);
+
+  await pullUpmBranch(packageJsonPath, branch, remote);
 }
 
 async function handleArgs() {

--- a/src/pull-upm-branch.ts
+++ b/src/pull-upm-branch.ts
@@ -1,0 +1,39 @@
+import path from "path";
+import simpleGit from "simple-git/promise";
+import { findRepoRoot } from "./utils/find-repo-root";
+
+export async function pullUpmBranch(
+    packageJsonPath: path.ParsedPath,
+    upmBranchName: string,
+    remoteName: string
+) {
+    const gitRepoPath = await findRepoRoot(packageJsonPath);
+    const gitRepoPathStr = path.format(gitRepoPath);
+  
+    const git = simpleGit(gitRepoPathStr);
+
+    try {
+        /** 
+         * The syntax is `git fetch remote branch:branch` which basically pulls the `branch` from `remote/branch` without switching to it.
+         * Source: https://stackoverflow.com/a/17722977/6301627
+         * 
+         * If this method ever fails, we have another option:
+         * 
+         * ```ts
+         * const currentBranch = ...;
+         * if(localExists) { 
+         *      git checkout branch
+         *      git pull remote branch
+         * } else {
+         *      git checkout --orphan branch remote/branch
+         *      git pull remote branch
+         * }
+         * git checkout currentBranch
+         * ```
+         */
+        await git.raw(["fetch", remoteName, `${upmBranchName}:${upmBranchName}`]);
+        console.log(`<pull-upm-branch> Pulled ${upmBranchName} from ${remoteName} successfully.`);
+    } catch (e) {
+        throw `Pull unsuccessful. Error: ${e}`;
+    }
+}

--- a/src/update-version.ts
+++ b/src/update-version.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { askNewVersion } from "./utils/ask-new-version";
 import { writeVersionToPackageJson } from "./utils/write-version-to-package-json";
 
-export async function updateVersion(packageJsonPath: path.ParsedPath, currentVersion: any) {
+export async function updateVersion(packageJsonPath: path.ParsedPath, currentVersion: string) {
   const newVersion = await askNewVersion(currentVersion);
   await writeVersionToPackageJson(packageJsonPath, newVersion);
   return newVersion;

--- a/src/update-version.ts
+++ b/src/update-version.ts
@@ -1,10 +1,8 @@
 import path from "path";
 import { askNewVersion } from "./utils/ask-new-version";
-import { learnVersion } from "./utils/learn-version";
 import { writeVersionToPackageJson } from "./utils/write-version-to-package-json";
 
-export async function updateVersion(packageJsonPath: path.ParsedPath) {
-  const currentVersion = await learnVersion(packageJsonPath);
+export async function updateVersion(packageJsonPath: path.ParsedPath, currentVersion: any) {
   const newVersion = await askNewVersion(currentVersion);
   await writeVersionToPackageJson(packageJsonPath, newVersion);
   return newVersion;

--- a/src/utils/has-local-branch.ts
+++ b/src/utils/has-local-branch.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import simpleGit from "simple-git/promise";
+import { findRepoRoot } from "./find-repo-root";
+
+/**
+ * Checks if the given branch exists locally.
+ */
+export async function hasLocalBranch(
+  packageJsonPath: path.ParsedPath,
+  branchName: string
+) {
+  const gitRepoPath = await findRepoRoot(packageJsonPath);
+  const gitRepoPathStr = path.format(gitRepoPath);
+
+  const git = simpleGit(gitRepoPathStr);
+  
+  const localBranches = await git.branchLocal();
+  return localBranches.branches.hasOwnProperty(branchName);
+}

--- a/src/utils/has-remote-branch.ts
+++ b/src/utils/has-remote-branch.ts
@@ -1,0 +1,23 @@
+import path from "path";
+import simpleGit from "simple-git/promise";
+import { findRepoRoot } from "./find-repo-root";
+
+/**
+ * Checks if the given branch exists on the given remote.
+ * 
+ * This function does not check if the remote exists. For that purpose, use `hasRemote` function.
+ */
+export async function hasRemoteBranch(
+  packageJsonPath: path.ParsedPath,
+  remoteName: string,
+  branchName: string
+) {
+  const gitRepoPath = await findRepoRoot(packageJsonPath);
+  const gitRepoPathStr = path.format(gitRepoPath);
+
+  const git = simpleGit(gitRepoPathStr);
+  
+  const listRemote = await git.listRemote(["--heads", remoteName, branchName]);
+  const isResultEmpty = listRemote.trim().length <= 0;
+  return !isResultEmpty;
+}

--- a/src/utils/has-remote.ts
+++ b/src/utils/has-remote.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import simpleGit from "simple-git/promise";
+import { findRepoRoot } from "./find-repo-root";
+
+/**
+ * Checks if there is a remote with the given name.
+ */
+export async function hasRemote(
+  packageJsonPath: path.ParsedPath,
+  remoteName: string
+) {
+  const gitRepoPath = await findRepoRoot(packageJsonPath);
+  const gitRepoPathStr = path.format(gitRepoPath);
+
+  const git = simpleGit(gitRepoPathStr);
+  
+  const remotes = await git.getRemotes(false);
+  return remotes.some(r => r.name === remoteName);
+}


### PR DESCRIPTION
Closes https://github.com/starikcetin/git-upm-publisher-2/issues/4

1. Remote and local branches are checked for existence and we take action appropriately.
1. If the remote branch exists, we pull it before and after the publishing process to keep it in sync.
1. Introduced a `remote` CLI argument to determine which remote we are using for the publishing.
1. If neither the local nor the remote branch exists, we treat it as a first release and do not prompt for version change.