### PR TITLE
Use 2 spaces instead of a tab for package.json formatting

### DIFF
--- a/src/utils/write-version-to-package-json.ts
+++ b/src/utils/write-version-to-package-json.ts
@@ -9,6 +9,6 @@ export async function writeVersionToPackageJson(
   let packageJsonData = await jsonfile.readFile(pathStr);
   packageJsonData["version"] = version;
   return jsonfile.writeFile(pathStr, packageJsonData, {
-    spaces: "\t"
+    spaces: 2
   });
 }


### PR DESCRIPTION
Closes #2 