### PR TITLE
Enabled strict mode for yargs

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs";
 
 export const args = yargs
+  .strict()
   .option("branch", {
     alias: "b",
     type: "string",


### PR DESCRIPTION
Fails-fast for any unrecognized arguments.

Closes #9 